### PR TITLE
file_url to file_name

### DIFF
--- a/src/server/db/schema/file.ts
+++ b/src/server/db/schema/file.ts
@@ -11,7 +11,7 @@ export const file = pgTable('file', {
     .notNull()
     .references(() => user.id),
   sectionId: text('section_id').references(() => section.id),
-  file_url: text('file_url').notNull(),
+  file_name: text('file_name').notNull(),
 });
 
 export const fileRelations = relations(file, ({ one }) => ({


### PR DESCRIPTION
We'll store the file_name instead of the file_url since that's how we query the bucket through the nebula api.