### PR TITLE
Empty State Component to be shown when no files available to display

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from 'next';
 import NavBar from '@components/NavBar';
+import EmptyState from '@components/EmptyState';
 
 export const metadata: Metadata = {
   alternates: {
@@ -11,6 +12,7 @@ const Home = () => {
   return (
     <>
       <NavBar />
+      <EmptyState />
     </>
   );
 };

--- a/src/components/EmptyState.tsx
+++ b/src/components/EmptyState.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+interface EmptyStateProps {
+  message?: string;
+}
+
+export default function EmptyState({ message = "No notes uploaded yet." }: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 px-4">
+      <div className="mb-4 text-gray-400">
+        <svg
+          className="w-16 h-16"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            strokeWidth={1.5}
+            d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"
+          />
+        </svg>
+      </div>
+      <p className="text-gray-500 text-center">{message}</p>
+    </div>
+  );
+}


### PR DESCRIPTION
Added empty state component as requested to be shown when no files available to display
closes #29 
<img width="1131" height="340" alt="image" src="https://github.com/user-attachments/assets/82aaca55-5a6c-4ecb-8951-0ce1a402caa4" />
