### PR TITLE
update next.js to fix new RCEs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,7 @@
         "dotenv": "^16.0.3",
         "drizzle-orm": "^0.44.3",
         "drizzle-zod": "^0.8.2",
-        "next": "^15.4.6",
+        "next": "^15.4.10",
         "next-auth": "^4.24.11",
         "postgres": "^3.3.5",
         "react": "^18.2.0",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "dotenv": "^16.0.3",
     "drizzle-orm": "^0.44.3",
     "drizzle-zod": "^0.8.2",
-    "next": "^15.4.6",
+    "next": "^15.4.10",
     "next-auth": "^4.24.11",
     "postgres": "^3.3.5",
     "react": "^18.2.0",


### PR DESCRIPTION
See [this](https://vercel.com/kb/bulletin/security-bulletin-cve-2025-55184-and-cve-2025-55183?inf_ver=2&inf_ctx=iWs_5UZHYW4A-9dbRUIKcM9Ibnp29XXXEh-M83BnkrXsL45pK2vNr_-V0eBYLxlSaj0fnF-VbF7oT1xNjqLdm8FRUnXogwcL1LzKfBgImJ45AUY1gryTZgIbgKA0c3G53qfBxjSSoBgkDb_YfH0HPntmYKlTlOMWXDEzdrdi5R7GKvn8aCjZFoPSOkkOSPIbSTuDN6o3XwqvjYGWG0t2i7ABGItzA9sVpUOrrZS1ZCZlwqAAcTkzA-eec9mGQgF8mynUxHrPOZMRGdFGDBqPUtOI4-jI5tnhyreow34izG9zBhOia-_YDPVbK4HI5AXOB2O6uO701v1QwpJbn5EzGg%3D%3D#patched-versions) blog post

"Following the [React2Shell](https://vercel.com/kb/bulletin/react2shell) disclosure, increased community research into React Server Components surfaced two additional vulnerabilities that require patching: a high-severity Denial of Service ([CVE-2025-55184](https://www.cve.org/CVERecord?id=CVE-2025-55184)) and a medium-severity Source Code Exposure ([CVE-2025-55183](https://www.cve.org/CVERecord?id=CVE-2025-55183)). They affect React 19 and frameworks that use it, like Next.js."