### PR TITLE
Create Note responsive side-by-side layout on desktop

### DIFF
--- a/src/app/notes/create/CreateNoteForm.tsx
+++ b/src/app/notes/create/CreateNoteForm.tsx
@@ -107,7 +107,7 @@ const FileForm = () => {
                       ? field.state.meta.errors
                           .map((err) => err?.message)
                           .join('. ') + '.'
-                      : undefined
+                      : 'Max file size 5MB'
                   }
                 />
               )}


### PR DESCRIPTION
## Create Note Responsive Side-by-Side Layout on Desktop

### What
- Updated the Create Note page layout to be responsive.
- Layout now switches from stacked (mobile) to side-by-side (desktop).
- File upload appears on the left, form inputs (Name, Description, Section) appear on the right for large screens.
- Layout remains constrained to `max-w-6xl`.

### Why
- Improves desktop usability and visual hierarchy.
- Makes better use of horizontal space on larger screens.
- Keeps mobile behavior unchanged.

### How
- Replaced single `flex flex-col` container with a responsive layout using:
  - `flex flex-col lg:flex-row`
  - `lg:w-5/12` for the upload section
  - `lg:w-7/12` for the form inputs
- Preserved existing form logic and mutations.
- No backend or schema changes.