### PR TITLE
docs: add max file size hint to note upload #86

### DIFF
--- a/src/app/notes/create/CreateNoteForm.tsx
+++ b/src/app/notes/create/CreateNoteForm.tsx
@@ -105,7 +105,7 @@ const FileForm = () => {
                       ? field.state.meta.errors
                           .map((err) => err?.message)
                           .join('. ') + '.'
-                      : undefined
+                      : "Max file size 5MB"
                   }
                 />
               )}


### PR DESCRIPTION
Added a text hint ("Max file size 5MB") to the FormFile component in CreateNoteForm.tsx to inform users of the upload limit.

Closes #86