### PR TITLE
fix typo: permenantly -> permanently

### DIFF
--- a/src/components/settings/DeleteButton.tsx
+++ b/src/components/settings/DeleteButton.tsx
@@ -27,7 +27,7 @@ export default function DeleteButton() {
         onClose={() => setOpen(false)}
         contentText={
           <>
-            This will permenantly delete your account. <br />
+            This will permanently delete your account. <br />
             All your account data will be cleared and removed from the platform.
           </>
         }

--- a/src/components/settings/forms/DeleteAccount.tsx
+++ b/src/components/settings/forms/DeleteAccount.tsx
@@ -8,7 +8,7 @@ export default function DeleteAccount() {
       className="bg-red-100 dark:bg-red-950 border border-red-500 dark:border-red-700"
       description={
         <div className="text-slate-800 dark:text-slate-200">
-          <p>This will permenantly delete your account from UTD Notebook.</p>
+          <p>This will permanently delete your account from UTD Notebook.</p>
         </div>
       }
     >


### PR DESCRIPTION
noticed the typo in the delete account message, changed "permenantly" to "permanently" in both places. was showing up in the ui and looked kinda unprofessional haha

fixed both components that had this text. should be good now, let me know if you need anything else 👍