### PR TITLE
Fix/filecard author name

### DIFF
--- a/src/components/sections/FileCard.tsx
+++ b/src/components/sections/FileCard.tsx
@@ -11,7 +11,13 @@ import { authClient } from '@src/utils/auth-client';
 import NoteEditButton from './NoteEditButton';
 
 type FileCardProps = {
-  file: SelectFile;
+  file: SelectFile & {
+    author?: {
+      username?: string | null;
+      firstName?: string | null;
+      lastName?: string | null;
+    };
+  };
 };
 
 const formatUpdatedAt = (updatedAt: SelectFile['updatedAt']) => {
@@ -107,7 +113,11 @@ export default function FileCard({ file }: FileCardProps) {
               {file.name}
             </h3>
             <p className="text-xs font-medium text-slate-600 dark:text-slate-400">
-              Uploaded by {file.authorId}
+              Uploaded by{' '}
+              {file.author
+                ? `${file.author.firstName ?? ''} ${file.author.lastName ?? ''}`.trim() ||
+                  file.author.username
+                : 'Unknown'}
             </p>
           </div>
 


### PR DESCRIPTION
Fixes #114

FileCard previously displayed the raw authorId UUID instead of the author's name.
This change renders the author's full name when available and falls back to username.