### PR TITLE
Fix typo 'permenantly' -> 'permanently' in Delete Account UI

### DIFF
--- a/src/components/settings/DeleteButton.tsx
+++ b/src/components/settings/DeleteButton.tsx
@@ -27,7 +27,7 @@ export default function DeleteButton() {
         onClose={() => setOpen(false)}
         contentText={
           <>
-            This will permenantly delete your account. <br />
+            This will permanently delete your account. <br />
             All your account data will be cleared and removed from the platform.
           </>
         }


### PR DESCRIPTION
Fixes #113

Corrects the spelling of "permenantly" to "permanently" in the Delete Account UI.