### PR TITLE
Add placeholder for Name when creating Notes

### DIFF
--- a/src/app/notes/create/NoteForm.tsx
+++ b/src/app/notes/create/NoteForm.tsx
@@ -173,7 +173,7 @@ const NoteForm = ({ mode = 'create', file: existingFile }: NoteFormProps) => {
                 {(field) => (
                   <field.TextField
                     label="Name"
-                    placeholder="Example: CS1200 Midterm Notes"
+                    placeholder="Example: Midterm Notes"
                     maxLength={100}
                     className="w-full"
                   />
@@ -212,7 +212,7 @@ const NoteForm = ({ mode = 'create', file: existingFile }: NoteFormProps) => {
                     <field.TextField
                       label="Section"
                       className="w-full"
-                      helperText=""
+                      helperText="Example: CS 1200.001 Fall 2025"
                     />
                   )}
                 </form.AppField>


### PR DESCRIPTION
Fixes #115

Added a placeholder to the Name input field on the Create Notes page
to guide users toward consistent naming.

File updated:
src/app/notes/create/NoteForm.tsx