### PR TITLE
Add empty state icon and fix condition (#29)

### DIFF
--- a/src/app/notes/[...slug]/page.tsx
+++ b/src/app/notes/[...slug]/page.tsx
@@ -128,9 +128,9 @@ export default async function NotesPage({ params }: NotesPageProps) {
         breadcrumbs={buildBreadcrumbs(query)}
       />
 
-      {sections.length === 0 ? (
+      {fileCount === 0 ? (
         <EmptyStateCard
-          title="No notes found"
+          title="No notes yet"
           description="No notes have been uploaded for this query yet."
         />
       ) : (

--- a/src/components/sections/EmptyStateCard.tsx
+++ b/src/components/sections/EmptyStateCard.tsx
@@ -1,16 +1,24 @@
+import type { SvgIconComponent } from '@mui/icons-material';
+import FolderOffIcon from '@mui/icons-material/FolderOff';
 import { BaseCard } from '@src/components/common/BaseCard';
 
 type EmptyStateCardProps = {
   title: string;
   description: string;
+  icon?: SvgIconComponent;
 };
 
 export default function EmptyStateCard({
   title,
   description,
+  icon: Icon = FolderOffIcon,
 }: EmptyStateCardProps) {
   return (
-    <BaseCard className="px-6 py-5 text-center">
+    <BaseCard className="px-6 py-8 text-center">
+      <Icon
+        className="mx-auto mb-3 text-slate-400 dark:text-slate-500"
+        sx={{ fontSize: 48 }}
+      />
       <h3 className="text-lg font-semibold">{title}</h3>
       <p className="mt-2 text-sm text-slate-600 dark:text-slate-400">
         {description}


### PR DESCRIPTION
## Summary
- Enhanced `EmptyStateCard` with a `FolderOffIcon` default and optional `icon` prop for customization
- Fixed the empty state condition on the notes page to check `fileCount === 0` instead of `sections.length === 0`, so pages like `/CS/2305` that have sections but no uploaded files correctly show the empty state
- Closes #29