### PR TITLE
Add sitemap

### DIFF
--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -9,7 +9,10 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
     const professors = (await api.section.getAllProfessors()).map(p => [p.profFirst, p.profLast]);
     const combos = (await api.section.getAllCourseProfessorCombos())
         .map(c => [c.prefix, c.number, c.profFirst, c.profLast]);
-    
+
+    // fetch note ids
+    const notes = (await api.file.byName({name: "", sortByDate: true})).map(f => [f.id]);
+
     // array of all possible note page slugs
     const noteSlugs = [...courses, ...professors, ...combos];
 
@@ -27,11 +30,18 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
             changeFrequency: 'weekly' as const,
             priority: 0.8,
         })),
+        // individual notes pages
+        ...notes.map((id) => ({
+            url: `${baseUrl}/notes/${id}`,
+            lastModified: new Date(),
+            changeFrequency: 'monthly' as const,
+            priority: 0.8,
+        })),
         { // create note page
             url: `${baseUrl}/notes/create`,
             lastModified: new Date(),
             changeFrequency: 'monthly' as const,
-            priority: .5,
-        }
+            priority: 0.5,
+        },
     ];
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -2,46 +2,60 @@ import { MetadataRoute } from 'next';
 import { api } from '@src/trpc/server';
 
 export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
-    const baseUrl = 'https://notebook.utdnebula.com';
+  const baseUrl = 'https://notebook.utdnebula.com';
 
-    // fetch all existing courses, profs, and course-prof combos as arrays
-    const courses = (await api.section.getAllCourses()).map(c => [c.prefix, c.number]);
-    const professors = (await api.section.getAllProfessors()).map(p => [p.profFirst, p.profLast]);
-    const combos = (await api.section.getAllCourseProfessorCombos())
-        .map(c => [c.prefix, c.number, c.profFirst, c.profLast]);
+  // fetch all existing courses, profs, and course-prof combos as arrays
+  const courses = (await api.section.getAllCourses()).map((c) => [
+    c.prefix,
+    c.number,
+  ]);
+  const professors = (await api.section.getAllProfessors()).map((p) => [
+    p.profFirst,
+    p.profLast,
+  ]);
+  const combos = (await api.section.getAllCourseProfessorCombos()).map((c) => [
+    c.prefix,
+    c.number,
+    c.profFirst,
+    c.profLast,
+  ]);
 
-    // fetch note ids
-    const notes = (await api.file.byName({name: "", sortByDate: true})).map(f => [f.id]);
+  // fetch note ids
+  const notes = (await api.file.byName({ name: '', sortByDate: true })).map(
+    (f) => [f.id],
+  );
 
-    // array of all possible note page slugs
-    const noteSlugs = [...courses, ...professors, ...combos];
+  // array of all possible note page slugs
+  const noteSlugs = [...courses, ...professors, ...combos];
 
-    return [
-        { // homepage
-            url: baseUrl,
-            lastModified: new Date(),
-            changeFrequency: 'monthly' as const,
-            priority: 1,
-        },
-        // notes pages
-        ...noteSlugs.map((slugs) => ({
-            url: `${baseUrl}/notes/${slugs.join("/")}`,
-            lastModified: new Date(),
-            changeFrequency: 'weekly' as const,
-            priority: 0.8,
-        })),
-        // individual notes pages
-        ...notes.map((id) => ({
-            url: `${baseUrl}/notes/${id}`,
-            lastModified: new Date(),
-            changeFrequency: 'monthly' as const,
-            priority: 0.8,
-        })),
-        { // create note page
-            url: `${baseUrl}/notes/create`,
-            lastModified: new Date(),
-            changeFrequency: 'monthly' as const,
-            priority: 0.5,
-        },
-    ];
+  return [
+    {
+      // homepage
+      url: baseUrl,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 1,
+    },
+    // notes pages
+    ...noteSlugs.map((slugs) => ({
+      url: `${baseUrl}/notes/${slugs.join('/')}`,
+      lastModified: new Date(),
+      changeFrequency: 'weekly' as const,
+      priority: 0.8,
+    })),
+    // individual notes pages
+    ...notes.map((id) => ({
+      url: `${baseUrl}/notes/${id}`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.8,
+    })),
+    {
+      // create note page
+      url: `${baseUrl}/notes/create`,
+      lastModified: new Date(),
+      changeFrequency: 'monthly' as const,
+      priority: 0.5,
+    },
+  ];
 }

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -22,7 +22,7 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
 
   // fetch note ids
   const notes = (await api.file.byName({ name: '', sortByDate: true })).map(
-    (f) => [f.id],
+    (f) => [f.id, f.updatedAt],
   );
 
   // array of all possible note page slugs
@@ -44,9 +44,9 @@ export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
       priority: 0.8,
     })),
     // individual notes pages
-    ...notes.map((id) => ({
+    ...notes.map(([id, updatedAt]) => ({
       url: `${baseUrl}/notes/${id}`,
-      lastModified: new Date(),
+      lastModified: updatedAt,
       changeFrequency: 'monthly' as const,
       priority: 0.8,
     })),

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,37 @@
+import { MetadataRoute } from 'next';
+import { api } from '@src/trpc/server';
+
+export default async function sitemap(): Promise<MetadataRoute.Sitemap> {
+    const baseUrl = 'https://notebook.utdnebula.com';
+
+    // fetch all existing courses, profs, and course-prof combos as arrays
+    const courses = (await api.section.getAllCourses()).map(c => [c.prefix, c.number]);
+    const professors = (await api.section.getAllProfessors()).map(p => [p.profFirst, p.profLast]);
+    const combos = (await api.section.getAllCourseProfessorCombos())
+        .map(c => [c.prefix, c.number, c.profFirst, c.profLast]);
+    
+    // array of all possible note page slugs
+    const noteSlugs = [...courses, ...professors, ...combos];
+
+    return [
+        { // homepage
+            url: baseUrl,
+            lastModified: new Date(),
+            changeFrequency: 'monthly' as const,
+            priority: 1,
+        },
+        // notes pages
+        ...noteSlugs.map((slugs) => ({
+            url: `${baseUrl}/notes/${slugs.join("/")}`,
+            lastModified: new Date(),
+            changeFrequency: 'weekly' as const,
+            priority: 0.8,
+        })),
+        { // create note page
+            url: `${baseUrl}/notes/create`,
+            lastModified: new Date(),
+            changeFrequency: 'monthly' as const,
+            priority: .5,
+        }
+    ];
+}

--- a/src/server/api/routers/section.ts
+++ b/src/server/api/routers/section.ts
@@ -110,44 +110,41 @@ export const sectionRouter = createTRPCRouter({
         ],
       });
     }),
-    
-  getAllCourses: publicProcedure
-    .query(async ({ ctx }) => {
-      return ctx.db
-        .selectDistinct({
-          prefix: section.prefix,
-          number: section.number,
-        })
-        .from(section)
-        .orderBy(section.prefix, section.number);
-    }),
 
-  getAllProfessors: publicProcedure
-    .query(async ({ ctx }) => {
-      return ctx.db
-        .selectDistinct({
-          profFirst: section.profFirst,
-          profLast: section.profLast,
-        })
-        .from(section)
-        .orderBy(section.profFirst, section.profLast);
-    }),
+  getAllCourses: publicProcedure.query(async ({ ctx }) => {
+    return ctx.db
+      .selectDistinct({
+        prefix: section.prefix,
+        number: section.number,
+      })
+      .from(section)
+      .orderBy(section.prefix, section.number);
+  }),
 
-  getAllCourseProfessorCombos: publicProcedure
-    .query(async ({ ctx }) => {
-      return ctx.db
-        .selectDistinct({
-          prefix: section.prefix,
-          number: section.number,
-          profFirst: section.profFirst,
-          profLast: section.profLast,
-        })
-        .from(section)
-        .orderBy(
-          section.prefix,
-          section.number,
-          section.profFirst,
-          section.profLast,
-        );
-    }),
+  getAllProfessors: publicProcedure.query(async ({ ctx }) => {
+    return ctx.db
+      .selectDistinct({
+        profFirst: section.profFirst,
+        profLast: section.profLast,
+      })
+      .from(section)
+      .orderBy(section.profFirst, section.profLast);
+  }),
+
+  getAllCourseProfessorCombos: publicProcedure.query(async ({ ctx }) => {
+    return ctx.db
+      .selectDistinct({
+        prefix: section.prefix,
+        number: section.number,
+        profFirst: section.profFirst,
+        profLast: section.profLast,
+      })
+      .from(section)
+      .orderBy(
+        section.prefix,
+        section.number,
+        section.profFirst,
+        section.profLast,
+      );
+  }),
 });

--- a/src/server/api/routers/section.ts
+++ b/src/server/api/routers/section.ts
@@ -110,4 +110,44 @@ export const sectionRouter = createTRPCRouter({
         ],
       });
     }),
+    
+  getAllCourses: publicProcedure
+    .query(async ({ ctx }) => {
+      return ctx.db
+        .selectDistinct({
+          prefix: section.prefix,
+          number: section.number,
+        })
+        .from(section)
+        .orderBy(section.prefix, section.number);
+    }),
+
+  getAllProfessors: publicProcedure
+    .query(async ({ ctx }) => {
+      return ctx.db
+        .selectDistinct({
+          profFirst: section.profFirst,
+          profLast: section.profLast,
+        })
+        .from(section)
+        .orderBy(section.profFirst, section.profLast);
+    }),
+
+  getAllCourseProfessorCombos: publicProcedure
+    .query(async ({ ctx }) => {
+      return ctx.db
+        .selectDistinct({
+          prefix: section.prefix,
+          number: section.number,
+          profFirst: section.profFirst,
+          profLast: section.profLast,
+        })
+        .from(section)
+        .orderBy(
+          section.prefix,
+          section.number,
+          section.profFirst,
+          section.profLast,
+        );
+    }),
 });


### PR DESCRIPTION
Added sitemap that lists the homepage, notes display pages (by course, professor, and course + professor), individual notes pages, and the create note page.

In order to get the slugs for course, professor, and course + professor, also added procedures to the section router to get all courses, all professors, and all course-professor combinations. 

Closes #3