### PR TITLE
fix: resolve greyed-out submit button on account creation (#154)

### DIFF
--- a/src/components/getting-started/OnboardingForm.tsx
+++ b/src/components/getting-started/OnboardingForm.tsx
@@ -228,8 +228,7 @@ export default function OnboardingForm({
       color={!form.state.isFieldsValid ? 'inherit' : 'primary'}
       onClick={handleBack}
       disabled={
-        activeStep.current === 0 ||
-        activeStep.current === steps.length - 1
+        activeStep.current === 0 || activeStep.current === steps.length - 1
       }
     >
       Back

--- a/src/components/getting-started/OnboardingForm.tsx
+++ b/src/components/getting-started/OnboardingForm.tsx
@@ -84,7 +84,7 @@ export default function OnboardingForm({
           userMetadata?.graduationDate?.getTime() +
             userMetadata?.graduationDate?.getTimezoneOffset() * 60 * 1000,
         )
-      : undefined,
+      : null,
     contactEmail: userMetadata?.contactEmail ?? '',
   });
 
@@ -213,10 +213,6 @@ export default function OnboardingForm({
   };
 
   const handleBack = () => {
-    // Validates mounted fields and prevents user from navigating if there exist errors
-    validateFields();
-    if (!currentFieldsValid()) return;
-
     if (activeStep.current > 0) {
       setActiveStep((prev) => ({
         current: prev.current - 1,
@@ -233,8 +229,7 @@ export default function OnboardingForm({
       onClick={handleBack}
       disabled={
         activeStep.current === 0 ||
-        activeStep.current === steps.length - 1 ||
-        !currentFieldsValid()
+        activeStep.current === steps.length - 1
       }
     >
       Back


### PR DESCRIPTION
## Summary

Fixes #154 -- the submit button was greyed out on step 3 (Contact Email) of account creation, even after entering a valid UTD email. The back button was also stuck.

## What was happening

The onboarding form uses a form-level `onChange` validator with `accountOnboardingSchema` (Zod v4). This means every time you type in any field, the **entire** schema validates all form values at once.

The `graduationDate` field defaulted to `undefined` for new users. But the schema defines it as `z.date().nullable()`, which accepts `Date | null` -- **not** `undefined`. So when you reached step 3 and started typing your UTD email, the form-level validator ran the full schema, hit the `graduationDate: undefined` mismatch, and the whole validation failed. This prevented the `contactEmail` field from ever being marked as valid, keeping the Submit button permanently disabled.

## Changes

- **`graduationDate` default: `undefined` to `null`** (line 87) -- `null` is a valid value per the schema, so the full-form validation no longer fails on unrelated fields when you're typing your email on step 3.

- **Removed validation blocking from `handleBack`** -- Previously, clicking Back also called `validateFields()` and blocked navigation if the current step was invalid. This meant you couldn't go back to fix anything. Users should always be able to navigate backward.