### PR TITLE
fix: default studentClassification to Student in onboarding

### DIFF
--- a/src/components/getting-started/OnboardingForm.tsx
+++ b/src/components/getting-started/OnboardingForm.tsx
@@ -76,7 +76,7 @@ export default function OnboardingForm({
     lastName: userMetadata?.lastName,
     major: userMetadata?.major,
     minor: userMetadata?.minor,
-    studentClassification: userMetadata?.studentClassification,
+    studentClassification: userMetadata?.studentClassification ?? 'Student',
     // `userMetadata.graduation` is automatically set with a time zone, which shows the wrong month in the date picker
     // Add the timezone offset (in milliseconds) to convert back to UTC
     graduationDate: userMetadata?.graduationDate


### PR DESCRIPTION
## Summary

Adds `?? 'Student'` fallback to the `studentClassification` default in the onboarding form, matching the pattern already used in the settings form. Without this, the value could be `undefined` for first-time Google sign-in users, causing form validation to silently fail and the submit button to stay greyed out.


Closes #154