### PR TITLE
Update settings header subtitle

### DIFF
--- a/src/components/settings/SettingsHeader.tsx
+++ b/src/components/settings/SettingsHeader.tsx
@@ -17,7 +17,7 @@ export default function SettingsHeader({ user }: SettingsHeaderProps) {
               Settings
             </h1>
             <span className="text-xl max-sm:text-lg max-sm:text-center text-white opacity-80">
-              Manage your account preferences
+              Manage your username and account preferences
             </span>
           </div>
           {user?.image && (


### PR DESCRIPTION
Updates the Settings page subtitle to "Manage your username and account preferences" to match the format used by UTD Clubs.